### PR TITLE
Add Pan/Zoom support for the graph surface (#458)

### DIFF
--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -107,6 +107,11 @@ namespace GraphControl
         void OnPointerEntered(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
         void OnPointerMoved(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
         void OnPointerExited(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+        void OnPointerWheelChanged(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+        void OnPointerPressed(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+        void OnPointerReleased(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+        void OnPointerCanceled(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+        void OnManipulationDelta(Windows::UI::Xaml::Input::ManipulationDeltaRoutedEventArgs^ e) override;
         #pragma endregion
 
     private:
@@ -122,6 +127,7 @@ namespace GraphControl
         void OnDataSourceChanged(GraphControl::InspectingDataSource^ sender, GraphControl::DataSourceChangedEventArgs args);
 
         void OnEquationsChanged(Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ args);
+        void OnEquationsVectorChanged(Windows::Foundation::Collections::IObservableVector<GraphControl::Equation ^> ^sender, Windows::Foundation::Collections::IVectorChangedEventArgs ^event);
         void OnEquationChanged();
 
         void UpdateGraph();
@@ -135,6 +141,8 @@ namespace GraphControl
         void SyncEquationsWithItemsSource();
         void OnItemsAdded(int index, int count);
         void OnItemsRemoved(int index, int count);
+
+        void ScaleRange(double centerX, double centerY, double scale);
 
     private:
         DX::RenderMain^ m_renderMain = nullptr;
@@ -155,6 +163,5 @@ namespace GraphControl
 
         const std::unique_ptr<Graphing::IMathSolver> m_solver;
         const std::shared_ptr<Graphing::IGraph> m_graph;
-        void OnEquationsVectorChanged(Windows::Foundation::Collections::IObservableVector<GraphControl::Equation ^> ^sender, Windows::Foundation::Collections::IVectorChangedEventArgs ^event);
-};
+    };
 }

--- a/src/GraphingInterfaces/GraphingEnums.h
+++ b/src/GraphingInterfaces/GraphingEnums.h
@@ -326,23 +326,17 @@ namespace Graphing
             //   Zoom out on all axes by the predefined ratio
             ZoomOut,
 
-            //   Zoom out on X axis only, leave the range of Y (and Z in 3D) unchanged
+            //   Zoom out on X axis only, leave the range of Y unchanged
             WidenX,
 
-            //   Zoom in on X axis only, leave the range of Y (and Z in 3D) unchanged
+            //   Zoom in on X axis only, leave the range of Y unchanged
             ShrinkX,
 
-            //   Zoom out on Y axis only, leave the range of X (and Z in 3D) unchanged
+            //   Zoom out on Y axis only, leave the range of X unchanged
             WidenY,
 
-            //   Zoom in on Y axis only, leave the range of X (and Z in 3D) unchanged
+            //   Zoom in on Y axis only, leave the range of X unchanged
             ShrinkY,
-
-            //   Zoom out on Z axis only, leave the range of X and Y unchanged. Apply to 3D graph only but not 2D graph.
-            WidenZ,
-
-            //   Zoom in on Z axis only, leave the range of X and Y unchanged. Apply to 3D graph only but not 2D graph.
-            ShrinkZ,
 
             //   Move the view window of the graph towards the negative X axis.
             MoveNegativeX,
@@ -355,12 +349,6 @@ namespace Graphing
 
             //   Move the view window of the graph towards the positive Y axis.
             MovePositiveY,
-
-            //   Move the view window of the graph towards the negative Z axis.
-            MoveNegativeZ,
-
-            //   Move the view window of the graph towards the positive Z axis.
-            MovePositiveZ,
 
             //   Zoom in on all axes by the predefined ratio. The ratio is smaller than used in ZoomIn result in a smoother motion
             SmoothZoomIn,

--- a/src/GraphingInterfaces/IGraphRenderer.h
+++ b/src/GraphingInterfaces/IGraphRenderer.h
@@ -16,5 +16,10 @@ namespace Graphing::Renderer
 
         virtual HRESULT DrawD2D1(ID2D1Factory* pDirect2dFactory, ID2D1RenderTarget* pRenderTarget, bool& hasSomeMissingDataOut) = 0;
         virtual HRESULT GetClosePointData(float inScreenPointX, float inScreenPointY, int& formulaIdOut, float& xScreenPointOut, float& yScreenPointOut, float& xValueOut, float& yValueOut) = 0;
+
+        virtual HRESULT ScaleRange(double centerX, double centerY, double scale) = 0;
+        virtual HRESULT ChangeRange(ChangeRangeAction action) = 0;
+        virtual HRESULT MoveRangeByRatio(double ratioX, double ratioY) = 0;
+        virtual HRESULT ResetRange() = 0;
     };
 }


### PR DESCRIPTION
Description of the changes:
Add Pan/Zoom support for the graph surface.
Currently only supports Mouse/Pen/Touch interactions. Keyboard support will be added separately.

How changes were validated:
Manual

## Fixes #.


### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

